### PR TITLE
refactor: Update project structure moving interface to project root

### DIFF
--- a/kvstore.go
+++ b/kvstore.go
@@ -15,7 +15,7 @@
 */
 
 // Package KVStore outlines how the key value store interface should be defined
-package KVStore
+package kvstore
 
 import (
 	"context"

--- a/kvstore_test.go
+++ b/kvstore_test.go
@@ -14,20 +14,21 @@
 	limitations under the License.
 */
 
-package tests
+package kvstore_test
 
 import (
 	"context"
-	"github.com/loopholelabs/kvstore/pkg/badger"
-	"github.com/loopholelabs/kvstore/pkg/etcd"
-	"github.com/loopholelabs/kvstore/pkg/etcd/embedded"
-	kvstore "github.com/loopholelabs/kvstore/pkg/kvstore"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
-	zap2 "go.uber.org/zap"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/loopholelabs/kvstore"
+	"github.com/loopholelabs/kvstore/pkg/badger"
+	"github.com/loopholelabs/kvstore/pkg/etcd"
+	"github.com/loopholelabs/kvstore/pkg/etcd/embedded"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	zap2 "go.uber.org/zap"
 )
 
 func RunAll(t *testing.T, fn func(db kvstore.KVStore)) {

--- a/pkg/badger/badger.go
+++ b/pkg/badger/badger.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/badger/v3/pb"
-	kvstore "github.com/loopholelabs/kvstore/pkg/kvstore"
+	"github.com/loopholelabs/kvstore"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -19,20 +19,21 @@ package etcd
 import (
 	"context"
 	"fmt"
-	kvstore "github.com/loopholelabs/kvstore/pkg/kvstore"
-	"github.com/loopholelabs/tls/pkg/config"
-	"github.com/loopholelabs/tls/pkg/loader"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
-	"go.etcd.io/etcd/client/pkg/v3/srv"
-	"go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/embed"
-	"go.uber.org/zap"
 	"net"
 	"strings"
 	"sync"
 	"time"
 	"unsafe"
+
+	"github.com/loopholelabs/kvstore"
+	"github.com/loopholelabs/tls/pkg/config"
+	"github.com/loopholelabs/tls/pkg/loader"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"go.etcd.io/etcd/client/pkg/v3/srv"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
+	"go.uber.org/zap"
 )
 
 var _ kvstore.KVStore = (*ETCD)(nil)


### PR DESCRIPTION
## Description
Updates the project structure so the generic key value store interface is available in the project root rather than a sub package

Fixes Issue ARCH-66

## Type of change
- [x] Refactor (non-breaking change which does not add functionality) [title: 'refactor:']

## Testing

If required please add new test cases and list them below:

## Final Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have signed-off my commits with `git commit -s` (see [the developer's certificate of origin](https://github.com/apps/dco))